### PR TITLE
Resolve cors and doorkeeper credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem "rack-cors"
+gem "rack-cors"
 
 gem 'devise'
 

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'bootsnap', require: false
 # gem "image_processing", "~> 1.2"
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-gem "rack-cors"
+gem 'rack-cors'
 
 gem 'devise'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.4)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
@@ -204,6 +206,7 @@ DEPENDENCIES
   doorkeeper
   pg (~> 1.1)
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.4, >= 7.0.4.3)
   rspec-rails (~> 5.0.0)
   shoulda-matchers (~> 5.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,12 @@ module ApartmentReservationBackEnd
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :options]
+      end
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,6 +53,10 @@ doorkeeper = Doorkeeper::Application.find_or_create_by(name: "React") do |app|
   app.save!
 end
 
-puts 'Doorkeeper Application has been created. Please use these values in the front-end'
-puts "client_id is #{doorkeeper.uid}"
-puts "client_secret is #{doorkeeper.read_attribute(:secret)}"
+LIGHTBLUE = "\e[1;34m"
+GREEN = "\e[1;32m"
+RESET = "\e[0m"
+
+puts "#{LIGHTBLUE}Doorkeeper Application has been created. Please use these values in the front-end#{RESET}"
+puts "client_id is #{GREEN}#{doorkeeper.uid}#{RESET}"
+puts "client_secret is #{GREEN}#{doorkeeper.read_attribute(:secret)}#{RESET}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,7 +48,11 @@ Reservation.create!(
 )
 
 # Doorkeeper record in oauth_application with uid/client_id and client_secret
-Doorkeeper::Application.find_or_create_by(name: "React") do |app|
+doorkeeper = Doorkeeper::Application.find_or_create_by(name: "React") do |app|
   app.redirect_uri = ""
   app.save!
 end
+
+puts 'Doorkeeper Application has been created. Please use these values in the front-end'
+puts "client_id is #{doorkeeper.uid}"
+puts "client_secret is #{doorkeeper.read_attribute(:secret)}"


### PR DESCRIPTION
In this branch, the following was achieved:

- Doorkeeper credentials have been added as a prompt for the console after `rails db:seed` command
- CORS requests were allowed